### PR TITLE
feat: sanitize api data and document server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+dados/imoveis.json

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Mapa de imóveis estilo Airbnb para Jericoacoara.
    npm run build:pontos
    ```
    Isso lê `dados/pontos/*.json` e gera `pontos.json` na raiz.
-3. Abra `mapa-airbnb.html` no navegador para visualizar o mapa.
+3. Inicie o servidor local para API e arquivos estáticos:
+   ```sh
+   npm start
+   ```
+   - `http://localhost:3000/mapa-airbnb.html` → visualiza o mapa
+   - `http://localhost:3000/adm.html` → cadastra imóveis (`POST /api/imoveis`)
+   - `http://localhost:3000/api/imoveis` → lista os imóveis cadastrados
+
+   Os dados enviados são persistidos em `dados/imoveis.json` (arquivo ignorado pelo Git).
 
 Os commits em `dados/pontos/**` disparam uma Action que recompila automaticamente o `pontos.json`.

--- a/adm.html
+++ b/adm.html
@@ -57,18 +57,22 @@
   document.getElementById('form-imovel').addEventListener('submit', async e => {
     e.preventDefault();
     const data = Object.fromEntries(new FormData(e.target).entries());
+    ['preco','latitude','longitude'].forEach(k => data[k] = Number(data[k]));
+    if (data.whatsapp) data.whatsapp = data.whatsapp.replace(/\D+/g, '');
     try {
-      const resp = await fetch('https://example.com/api/imoveis', {
+      const resp = await fetch('/api/imoveis', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data)
       });
-      if (!resp.ok) throw new Error('HTTP ' + resp.status);
+      let result = {};
+      try { result = await resp.json(); } catch (_) {}
+      if (!resp.ok || !result.ok) throw new Error(result.error || ('HTTP ' + resp.status));
       alert('Enviado com sucesso!');
       e.target.reset();
     } catch (err) {
       console.error('Erro ao enviar', err);
-      alert('Falha ao enviar, ver console.');
+      alert('Falha ao enviar: ' + err.message);
     }
   });
   </script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "type": "module",
   "scripts": {
-    "build:pontos": "node scripts/compile-pontos.js"
+    "build:pontos": "node scripts/compile-pontos.js",
+    "start": "node server.js"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,104 @@
+import http from 'http';
+import { promises as fs } from 'fs';
+import path from 'path';
+import url from 'url';
+import crypto from 'crypto';
+
+const dbPath = path.join(process.cwd(), 'dados', 'imoveis.json');
+const numericFields = ['preco', 'latitude', 'longitude'];
+const onlyDigits = s => (s || '').toString().replace(/\D+/g, '');
+
+async function readDb() {
+  try {
+    const data = await fs.readFile(dbPath, 'utf8');
+    return JSON.parse(data);
+  } catch (err) {
+    if (err.code === 'ENOENT') return [];
+    throw err;
+  }
+}
+
+async function writeDb(data) {
+  await fs.mkdir(path.dirname(dbPath), { recursive: true });
+  await fs.writeFile(dbPath, JSON.stringify(data, null, 2));
+}
+
+function getContentType(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  return {
+    '.html': 'text/html; charset=utf-8',
+    '.js': 'application/javascript; charset=utf-8',
+    '.css': 'text/css; charset=utf-8',
+    '.json': 'application/json; charset=utf-8'
+  }[ext] || 'application/octet-stream';
+}
+
+async function serveStatic(req, res) {
+  let filePath = url.parse(req.url).pathname;
+  if (filePath === '/') filePath = '/index.html';
+  const fullPath = path.join(process.cwd(), filePath);
+  try {
+    const data = await fs.readFile(fullPath);
+    res.writeHead(200, { 'Content-Type': getContentType(fullPath) });
+    res.end(data);
+  } catch (err) {
+    res.writeHead(404);
+    res.end('Not Found');
+  }
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', chunk => data += chunk);
+    req.on('end', () => {
+      try {
+        resolve(JSON.parse(data || '{}'));
+      } catch (err) {
+        reject(err);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  const { pathname } = url.parse(req.url);
+  if (req.method === 'POST' && pathname === '/api/imoveis') {
+    try {
+      const body = await readBody(req);
+      const data = { ...body };
+      for (const f of numericFields) data[f] = Number(data[f]);
+      data.whatsapp = onlyDigits(data.whatsapp);
+      const imovel = { id: crypto.randomUUID(), ...data };
+      const lista = await readDb();
+      lista.push(imovel);
+      await writeDb(lista);
+      res.writeHead(201, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, id: imovel.id }));
+    } catch (err) {
+      console.error('Erro ao salvar', err);
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: false, error: 'erro_ao_salvar' }));
+    }
+  } else if (req.method === 'GET' && pathname === '/api/imoveis') {
+    try {
+      const lista = await readDb();
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(lista));
+    } catch (err) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: false }));
+    }
+  } else if (req.method === 'GET') {
+    await serveStatic(req, res);
+  } else {
+    res.writeHead(404);
+    res.end('Not Found');
+  }
+});
+
+const port = process.env.PORT || 3000;
+server.listen(port, () => {
+  console.log(`Servidor rodando em http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- sanitize numeric and WhatsApp fields before saving
- expose GET /api/imoveis and persist submissions locally
- document server usage and data storage in README

## Testing
- `npm run build:pontos`
- `curl -s -X POST http://localhost:3000/api/imoveis -H "Content-Type: application/json" -d '{"nome":"Outro","descricao":"Lote","preco":50000,"tipo":"terreno","status":"disponivel","latitude":-2.9,"longitude":-60.1}'`
- `curl -s http://localhost:3000/api/imoveis | jq .`


------
https://chatgpt.com/codex/tasks/task_e_68aa155745c08333a6e9b2d42f739475