### PR TITLE
feat: configurable API base url

### DIFF
--- a/adm.html
+++ b/adm.html
@@ -10,6 +10,7 @@
     input, textarea, select { width:100%; padding:6px 8px; margin-top:4px; font-size:14px; }
     button { padding:8px 16px; font-size:14px; font-weight:600; margin-top:10px; }
   </style>
+  <script src="config.js"></script>
 </head>
 <body>
   <h1>Cadastrar Imóvel</h1>
@@ -58,7 +59,7 @@
     e.preventDefault();
     const data = Object.fromEntries(new FormData(e.target).entries());
     try {
-      const resp = await fetch('/api/imoveis', {
+      const resp = await fetch(`${API_BASE_URL}/imoveis`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data)


### PR DESCRIPTION
## Summary
- serve dynamic config.js with API_BASE_URL
- allow GET /api/imoveis and configure client fetch to use API_BASE_URL

## Testing
- `curl -s -X POST http://localhost:3000/api/imoveis -H 'Content-Type: application/json' -d '{"nome":"Test","preco":100,"latitude":1.23,"longitude":4.56}'`
- `curl -s http://localhost:3000/api/imoveis`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa1ea1bf908333ad053be20b0ab78f