### PR TITLE
Fix mapa-airbnb default view and data loading

### DIFF
--- a/mapa-airbnb.html
+++ b/mapa-airbnb.html
@@ -98,7 +98,7 @@
   // === MAPBOX: seu token + seu style ===
   mapboxgl.accessToken = 'pk.eyJ1IjoiZGVuaWxzb25qZXJpIiwiYSI6ImNtZDRuNWpyazA0MTgyaXBwNGszNDB1amUifQ.6ZO0WpmlmUBd7_n8URaMIQ';
   const STYLE_URL = 'mapbox://styles/denilsonjeri/cmd9200z8007101s2e47a3nej';
-  const START = { center: [-2.8136, -40.4141], zoom: 5 }; // Praia do Prea
+  const START = { center: [-40.4141, -2.8136], zoom: 12 }; // Praia do Prea
 
   const map = new mapboxgl.Map({
     container: 'map',
@@ -148,39 +148,19 @@
       const res = await fetch('./pontos.json?ts=' + Date.now(), { cache: 'no-store' });
       if (!res.ok) {
         console.warn('[mapa-airbnb] pontos.json não retornou 200 OK:', res.status, res.statusText);
-        return (window.ALL = []);
+        ALL = [];
+        return;
       }
       const arr = await res.json();
       if (!Array.isArray(arr) || arr.length === 0) {
         console.warn('[mapa-airbnb] pontos.json vazio ou inválido.');
-        return (window.ALL = []);
+        ALL = [];
+        return;
       }
-      window.ALL = arr.map((item, idx) => {
-        const lng = Number(item.longitude), lat = Number(item.latitude);
-        if (!Number.isFinite(lng) || !Number.isFinite(lat)) return null;
-        return {
-          type: 'Feature',
-          properties: {
-            id: item.id || `imv_${idx}`,
-            titulo: item.nome || 'Imóvel',
-            descricao: item.descricao || '',
-            preco: Number(item.preco) || 0,
-            tipo: (item.tipo || '').toLowerCase(),
-            status: (item.status || 'disponivel').toLowerCase(),
-            capa: item.imagem_capa || '',
-            galeria: item.galeria || [],
-            url: item.url || '',
-            whatsapp: (item.whatsapp || '').toString(),
-            quartos: Number(item.quartos || 0),
-            area_m2: Number(item.area_m2 || 0),
-            financia: !!item.financia
-          },
-          geometry: { type:'Point', coordinates: [lng, lat] }
-        };
-      }).filter(Boolean);
+      ALL = arr.map(toFeature).filter(Boolean);
     } catch (err) {
       console.warn('[mapa-airbnb] falha ao carregar pontos.json:', err);
-      window.ALL = [];
+      ALL = [];
     }
   }
 


### PR DESCRIPTION
### Motivation

- Corrigir o centro/zoom inicial do mapa para exibir corretamente a Praia do Prea.  
- Unificar o parsing dos itens para reutilizar a função `toFeature` e evitar duplicação de lógica.  
- Evitar atribuir dados ao `window` global e manter o estado no array local `ALL`.  
- Tornar o carregamento de `pontos.json` mais robusto contra erros/respostas inválidas.  

### Description

- Ajustado o valor de `START` em `mapa-airbnb.html` para `center: [-40.4141, -2.8136]` e `zoom: 12`.  
- Substituído o mapeamento inline em `loadData` por `ALL = arr.map(toFeature).filter(Boolean)` para reaproveitar a conversão existente.  
- Simplificada a lógica de erro em `loadData` para definir `ALL = []` quando houver falha ou dados inválidos, removendo o uso de `window.ALL`.  
- Nenhuma alteração no comportamento de clusters, marcadores e popups além das correções acima.  

### Testing

- Servido o projeto com `python -m http.server` e carregado `mapa-airbnb.html` em um navegador headless via `Playwright` para validar a renderização.  
- A execução do Playwright gerou um screenshot (`artifacts/mapa-airbnb.png`) e os logs do servidor mostram `GET /pontos.json` retornando `200`.  
- Não foram executados testes unitários automatizados.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695953d6f044833386eb93018b9ad35e)